### PR TITLE
Conditionally Hide Routes in Sidebar

### DIFF
--- a/src/components/sidebar/components/Links.js
+++ b/src/components/sidebar/components/Links.js
@@ -26,105 +26,114 @@ export function SidebarLinks(props) {
   // this function creates the links from the secondary accordions (for example auth -> sign-in -> default)
   const createLinks = (routes) => {
     return routes.map((route, index) => {
-      if (route.category) {
-        return (
-          <>
-            <Text
-              fontSize={"md"}
-              color={activeColor}
-              fontWeight='bold'
-              mx='auto'
-              ps={{
-                sm: "10px",
-                xl: "16px",
-              }}
-              pt='18px'
-              pb='12px'
-              key={index}>
-              {route.name}
-            </Text>
-            {createLinks(route.items)}
-          </>
-        );
-      } else if (
-        route.layout === "/admin" ||
-        route.layout === "/auth" ||
-        route.layout === "/rtl"
-      ) {
-        return (
-          <NavLink key={index} to={route.layout + route.path}>
-            {route.icon ? (
-              <Box>
-                <HStack
-                  spacing={
-                    activeRoute(route.path.toLowerCase()) ? "22px" : "26px"
-                  }
-                  py='5px'
-                  ps='10px'>
-                  <Flex w='100%' alignItems='center' justifyContent='center'>
+      if (!route.hidden)
+        if (route.category) {
+          return (
+            <>
+              <Text
+                fontSize={"md"}
+                color={activeColor}
+                fontWeight="bold"
+                mx="auto"
+                ps={{
+                  sm: "10px",
+                  xl: "16px",
+                }}
+                pt="18px"
+                pb="12px"
+                key={index}
+              >
+                {route.name}
+              </Text>
+              {createLinks(route.items)}
+            </>
+          );
+        } else if (
+          route.layout === "/admin" ||
+          route.layout === "/auth" ||
+          route.layout === "/rtl"
+        ) {
+          return (
+            <NavLink key={index} to={route.layout + route.path}>
+              {route.icon ? (
+                <Box>
+                  <HStack
+                    spacing={
+                      activeRoute(route.path.toLowerCase()) ? "22px" : "26px"
+                    }
+                    py="5px"
+                    ps="10px"
+                  >
+                    <Flex w="100%" alignItems="center" justifyContent="center">
+                      <Box
+                        color={
+                          activeRoute(route.path.toLowerCase())
+                            ? activeIcon
+                            : textColor
+                        }
+                        me="18px"
+                      >
+                        {route.icon}
+                      </Box>
+                      <Text
+                        me="auto"
+                        color={
+                          activeRoute(route.path.toLowerCase())
+                            ? activeColor
+                            : textColor
+                        }
+                        fontWeight={
+                          activeRoute(route.path.toLowerCase())
+                            ? "bold"
+                            : "normal"
+                        }
+                      >
+                        {route.name}
+                      </Text>
+                    </Flex>
                     <Box
-                      color={
+                      h="36px"
+                      w="4px"
+                      bg={
                         activeRoute(route.path.toLowerCase())
-                          ? activeIcon
-                          : textColor
+                          ? brandColor
+                          : "transparent"
                       }
-                      me='18px'>
-                      {route.icon}
-                    </Box>
+                      borderRadius="5px"
+                    />
+                  </HStack>
+                </Box>
+              ) : (
+                <Box>
+                  <HStack
+                    spacing={
+                      activeRoute(route.path.toLowerCase()) ? "22px" : "26px"
+                    }
+                    py="5px"
+                    ps="10px"
+                  >
                     <Text
-                      me='auto'
+                      me="auto"
                       color={
                         activeRoute(route.path.toLowerCase())
                           ? activeColor
-                          : textColor
+                          : inactiveColor
                       }
                       fontWeight={
                         activeRoute(route.path.toLowerCase())
                           ? "bold"
                           : "normal"
-                      }>
+                      }
+                    >
                       {route.name}
                     </Text>
-                  </Flex>
-                  <Box
-                    h='36px'
-                    w='4px'
-                    bg={
-                      activeRoute(route.path.toLowerCase())
-                        ? brandColor
-                        : "transparent"
-                    }
-                    borderRadius='5px'
-                  />
-                </HStack>
-              </Box>
-            ) : (
-              <Box>
-                <HStack
-                  spacing={
-                    activeRoute(route.path.toLowerCase()) ? "22px" : "26px"
-                  }
-                  py='5px'
-                  ps='10px'>
-                  <Text
-                    me='auto'
-                    color={
-                      activeRoute(route.path.toLowerCase())
-                        ? activeColor
-                        : inactiveColor
-                    }
-                    fontWeight={
-                      activeRoute(route.path.toLowerCase()) ? "bold" : "normal"
-                    }>
-                    {route.name}
-                  </Text>
-                  <Box h='36px' w='4px' bg='brand.400' borderRadius='5px' />
-                </HStack>
-              </Box>
-            )}
-          </NavLink>
-        );
-      }
+                    <Box h="36px" w="4px" bg="brand.400" borderRadius="5px" />
+                  </HStack>
+                </Box>
+              )}
+            </NavLink>
+          );
+        }
     });
   };
   //  BRAND


### PR DESCRIPTION
**Pull Request Description**
A `hidden` prop can be added in `routes.js` that would still be loaded into the `react-router`, but not rendered in the Sidenav.
This will allow devs to not have to manually create custom router logic for their nested routes.

The resolves issue https://github.com/horizon-ui/horizon-ui-chakra/issues/21.