### PR TITLE
fix: fixed bottom margin for breadcrumbs

### DIFF
--- a/src/components/navbar/NavbarAdmin.js
+++ b/src/components/navbar/NavbarAdmin.js
@@ -95,7 +95,7 @@ export default function AdminNavbar(props) {
 							</BreadcrumbLink>
 						</BreadcrumbItem>
 
-						<BreadcrumbItem color={secondaryText} fontSize='sm'>
+						<BreadcrumbItem color={secondaryText} fontSize='sm' mb='5px'>
 							<BreadcrumbLink href='#' color={secondaryText}>
 								{brandText}
 							</BreadcrumbLink>


### PR DESCRIPTION
Fixed the breadcrumb margin.

Before fix:
<img width="156" alt="image" src="https://github.com/horizon-ui/horizon-ui-chakra/assets/5072806/9227702a-269a-46b7-838e-d3e8c40fea99">

After fix:
<img width="124" alt="image" src="https://github.com/horizon-ui/horizon-ui-chakra/assets/5072806/0d392bbc-1868-4877-91ef-0db6c61ddc01">
