### PR TITLE
docs: add Deploy on Hostinger button

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,7 @@ new people that already use Horizon UI!
 ⭐️ [Copyright 2023 Simmmple ](https://www.simmmple.com/?ref=readme-horizon)
 
 📄 [Horizon UI License](https://www.simmmple.com/licenses?ref=readme-horizon)
+
+## Deployment
+
+[![Deploy on Hostinger](https://assets.hostinger.com/vps/deploy.svg)](https://www.hostinger.com/web-apps-hosting)


### PR DESCRIPTION
This PR adds a "Deploy on Hostinger" button to the README for one-click hosting discovery.

- Button points to: https://www.hostinger.com/web-apps-hosting
- Only README was changed.